### PR TITLE
Aggiunto supporto a pagina personalizzata per la Cookie Policy

### DIFF
--- a/italiawp2/footer.php
+++ b/italiawp2/footer.php
@@ -217,6 +217,9 @@
                 <?php if(get_option('dettagli-id-privacy')!=""): ?>
                     <a href="<?php echo get_permalink(get_option('dettagli-id-privacy')); ?>" title="<?php echo __('Privacy policy','italiawp2'); ?>"><?php echo __('Privacy','italiawp2'); ?></a> |
                 <?php endif; ?>
+                <?php if(get_option('dettagli-id-cookie')!=""): ?>
+                    <a href="<?php echo get_permalink(get_option('dettagli-id-cookie')); ?>" title="<?php echo __('Cookie policy','italiawp2'); ?>"><?php echo __('Cookie policy','italiawp2'); ?></a> |
+                <?php endif; ?>
                 <?php if(get_option('dettagli-id-notelegali')!=""): ?>
                     <a href="<?php echo get_permalink(get_option('dettagli-id-notelegali')); ?>" title="<?php echo __('Legal notices','italiawp2'); ?>"><?php echo __('Legal notices','italiawp2'); ?></a> |
                 <?php endif; ?>

--- a/italiawp2/header.php
+++ b/italiawp2/header.php
@@ -53,6 +53,11 @@
 </head>
 
 <body class="t-Pac">
+
+<?php
+$page_id_cookie_banner = get_option('dettagli-id-cookie');
+if (!$page_id_cookie_banner) $page_id_cookie_banner = get_option('dettagli-id-privacy');
+?>
     
 <div class="cookiebar hide u-background-80" aria-hidden="true">
     <p class="text-white">
@@ -61,7 +66,7 @@
         <button data-accept="cookiebar" class="btn btn-info mr-2 btn-verde">
             <?php echo __('I accept','italiawp2'); ?>
         </button>
-        <a href="<?php echo get_permalink(get_option('dettagli-id-privacy')); ?>" class="btn btn-outline-info btn-trasp"><?php echo __('Privacy policy','italiawp2'); ?></a>
+        <a href="<?php echo get_permalink(get_option($page_id_cookie)); ?>" class="btn btn-outline-info btn-trasp"><?php echo __('Cookie policy','italiawp2'); ?></a>
     </p>
 </div>
     

--- a/italiawp2/inc/details.php
+++ b/italiawp2/inc/details.php
@@ -39,6 +39,9 @@ function italiawp2_edit_custom_settings() { ?>
             <p><strong>ID pagina Privacy:</strong><br />
                 <input type="text" name="dettagli-id-privacy" size="10" value="<?php echo get_option('dettagli-id-privacy'); ?>" /></p>
             
+            <p><strong>ID pagina Cookie policy:</strong><br />
+                <input type="text" name="dettagli-id-cookie" size="10" value="<?php echo get_option('dettagli-id-cookie'); ?>" /></p>
+            
             <p><strong>ID pagina Note legali:</strong><br />
                 <input type="text" name="dettagli-id-notelegali" size="10" value="<?php echo get_option('dettagli-id-notelegali'); ?>" /></p>
             
@@ -115,7 +118,7 @@ function italiawp2_edit_custom_settings() { ?>
                                                             custom-meta-keywords,custom-meta-description,
                                                             dettagli-link-accessibilita,
                                                             dettagli-nome-ammin-afferente,dettagli-url-ammin-afferente,
-                                                            dettagli-id-privacy,dettagli-id-notelegali,dettagli-id-contatti,
+                                                            dettagli-id-privacy,dettagli-id-cookie,dettagli-id-notelegali,dettagli-id-contatti,
                                                             dettagli-indirizzo,dettagli-cap,dettagli-citta,dettagli-telefono,dettagli-fax,
                                                             dettagli-email,dettagli-pec,dettagli-cfpiva,dettagli-facebook,
                                                             dettagli-twitter,dettagli-youtube,dettagli-instagram,


### PR DESCRIPTION
Dato che alcuni siti mantengono la Cookie Policy separata dalla Privacy Policy ho:
- introdotto un campo per l'inserimento dell'ID pagina "Cookie policy" nell'area dettagli
- aggiunto il link della pagina nel footer
- modificato il link della CTA presente nel banner cookie.