### PR TITLE
Alcuni fix minori

### DIFF
--- a/italiawp2/front-page.php
+++ b/italiawp2/front-page.php
@@ -14,9 +14,8 @@ if (get_theme_mod('active_section_last_news')):
     get_template_part('template-parts/section-last-news');
 endif;
 
-/* Inizio Sezione Ultime circolari (se è installato il plugin "Gestione Circolari") */
-include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
-if ( is_plugin_active('gestione-circolari/GestioneCircolari.php') && get_theme_mod('active_section_circolari') ):
+/* Inizio Sezione Ultime circolari (se è installato il plugin "Gestione Circolari" e di conseguenza esiste su widget CircolariWidget) */
+if ( class_exists('CircolariWidget') && get_theme_mod('active_section_circolari') ):
     get_template_part('template-parts/section-last-circolari');
 endif;
 /* Fine Sezione Ultime circolari */

--- a/italiawp2/functions.php
+++ b/italiawp2/functions.php
@@ -120,6 +120,16 @@ if (!function_exists('italiawp2_theme_setup')) :
         // Aggiungo dei colori da utilizzare con l'editor
         add_theme_support('editor-color-palette',
                 array(
+	                array(
+		                'name' => __('black', 'italiawp2'),
+		                'slug' => 'colore-nero',
+		                'color' => get_option('italiawp2_colore_nero'),
+	                ),
+	                array(
+		                'name' => __('white', 'italiawp2'),
+		                'slug' => 'colore-bianco',
+		                'color' => get_option('italiawp2_colore_bianco'),
+	                ),
                     array(
                         'name' => __('Primary Color', 'italiawp2'),
                         'slug' => 'colore-primario',
@@ -256,16 +266,14 @@ function italiawp2_custom_login_logo() {
     echo '</style>';
 }
 
-add_action('login_head', 'italiawp2_custom_login_logo');
 
+add_action('login_head', 'italiawp2_custom_login_logo');
+add_filter('login_headerurl', 'italiawp2_custom_login_url');
 function italiawp2_custom_login_url() {
-    return get_site_url();
+    return home_url();
 }
 
-add_filter('login_headerurl', 'italiawp2_custom_login_url');
-
 add_filter('previous_posts_link_attributes', 'posts_link_attributes');
-
 function posts_link_attributes() {
     return 'class="u-color-50"';
 }

--- a/italiawp2/functions.php
+++ b/italiawp2/functions.php
@@ -323,7 +323,7 @@ function italiawp2_create_breadcrumbs() {
                 echo '<li class="breadcrumb-item"><a href="' . get_term_link($cat->cat_ID, false) . '">' . $cat->cat_name . '</a><span class="separator">/</span></li>';
                 echo $before . get_the_title() . $after;
             }
-        } elseif (!is_single() && !is_page() && get_post_type() != 'post' && !is_404()) {
+        } elseif (!is_single() && !is_page() && get_post_type() != 'post' && !is_404() && !is_search()) {
             $post_type = get_post_type_object(get_post_type());
             echo $before . $post_type->labels->singular_name . $after;
         } elseif (is_attachment()) {

--- a/italiawp2/inc/style.php
+++ b/italiawp2/inc/style.php
@@ -1,6 +1,5 @@
 <?php
-
-include_once('colors.php');
+get_template_part('inc/colors');
 
 function italiawp2_css_strip_whitespace($css){
 	  $replace = array(
@@ -97,36 +96,27 @@ function italiawp2_dymanic_styles() {
     
     //$color_compl_link_footer = colorSetSL($main_color, 100, 80);
     $color_compl_link_footer = hsl2hex(array($color_compl_HSL[0], (100/100), (80/100) ));
-    
-    if (get_option('italiawp2_colore_primario'))
-        update_option('italiawp2_colore_primario', $color_50);
-    else
-        add_option('italiawp2_colore_primario', $color_50);
 
-    if (get_option('italiawp2_colore_primario_chiaro'))
-        update_option('italiawp2_colore_primario_chiaro', $color_30);
-    else
-        add_option('italiawp2_colore_primario_chiaro', $color_30);
-
-    if (get_option('italiawp2_colore_primario_scuro'))
-        update_option('italiawp2_colore_primario_scuro', $color_95);
-    else
-        add_option('italiawp2_colore_primario_scuro', $color_95);
-
-    if (get_option('italiawp2_colore_complementare'))
-        update_option('italiawp2_colore_complementare', $color_compl);
-    else
-        add_option('italiawp2_colore_complementare', $color_compl);
+	get_option( 'italiawp2_colore_primario' ) ? update_option( 'italiawp2_colore_primario', $color_50 ) : add_option( 'italiawp2_colore_primario', $color_50 );
+	get_option( 'italiawp2_colore_primario_chiaro' ) ? update_option( 'italiawp2_colore_primario_chiaro', $color_30 ) : add_option( 'italiawp2_colore_primario_chiaro', $color_30 );
+	get_option( 'italiawp2_colore_primario_scuro' ) ? update_option( 'italiawp2_colore_primario_scuro', $color_95 ) : add_option( 'italiawp2_colore_primario_scuro', $color_95 );
+	get_option( 'italiawp2_colore_complementare' ) ? update_option( 'italiawp2_colore_complementare', $color_compl ) : add_option( 'italiawp2_colore_complementare', $color_compl );
+	get_option( 'italiawp2_colore_nero' ) ? update_option( 'italiawp2_colore_nero', $color_black ) : add_option( 'italiawp2_colore_nero', $color_black );
+	get_option( 'italiawp2_colore_bianco' ) ? update_option( 'italiawp2_colore_bianco', $color_white ) : add_option( 'italiawp2_colore_bianco', $color_white );
 
     $custom_css = "
+    
+.has-colore-nero-color,
 .u-color-black {
   color: {$color_black} !important;
 }
 
+.has-colore-nero-background-color,
 .u-background-black {
   background-color: {$color_black} !important;
 }
 
+.has-colore-bianco-color,
 .u-color-white,
 .Bullets>li:before, .Footer, .Footer-blockTitle, .Footer-subTitle, .Form-input.Form-input:focus+[role=tooltip],
 .Linklist-link.Linklist-link--lev1, .Linklist-link.Linklist-link--lev1:hover, .Megamenu--default .Megamenu-item>a,
@@ -135,6 +125,7 @@ function italiawp2_dymanic_styles() {
   color: {$color_white} !important;
 }
 
+.has-colore-bianco-background-color,
 .u-background-white,
 .Megamenu--default .Megamenu-subnav, .Skiplinks>li>a, .Spid-menu {
   background-color: {$color_white} !important;

--- a/italiawp2/template-parts/archive-circolari-loop.php
+++ b/italiawp2/template-parts/archive-circolari-loop.php
@@ -95,11 +95,11 @@ $i = 0; if (have_posts()) :
             </div>
 
 <?php endwhile;
-      else : include('error.php');
+      else : get_template_part('template-parts','error');
       endif; ?>
 
         </div>
     </div>
 </section>
 
-<?php include_once('pagination.php');
+<?php get_template_part('template-parts','pagination');

--- a/italiawp2/template-parts/archive-gallerie-loop.php
+++ b/italiawp2/template-parts/archive-gallerie-loop.php
@@ -86,11 +86,11 @@ $i = 0; if (have_posts()) :
             </div>
 
 <?php endwhile;
-      else : include('error.php');
+      else : get_template_part('template-parts','error');
       endif; ?>
 
         </div>
     </div>
 </section>
 
-<?php include_once('pagination.php');
+<?php get_template_part('template-parts','pagination');

--- a/italiawp2/template-parts/archive-loop.php
+++ b/italiawp2/template-parts/archive-loop.php
@@ -139,11 +139,11 @@ $i = 0; if (have_posts()) :
             </div>
 
 <?php endwhile;
-      else : include('error.php');
+      else : get_template_part('template-parts','error');
       endif; ?>
 
         </div>
     </div>
 </section>
 
-<?php include_once('pagination.php');
+<?php get_template_part('template-parts','pagination');

--- a/italiawp2/template-parts/attachment-loop.php
+++ b/italiawp2/template-parts/attachment-loop.php
@@ -26,12 +26,12 @@ if (have_posts()) : while (have_posts()) : the_post(); ?>
                 <div class="row">
                     <div class="col-lg-3 col-md-4 lineright">
                         <aside id="menu-sinistro">
-                            <?php include_once('children-list.php'); ?>
+                            <?php get_template_part('template-parts','children-list'); ?>
             
                             <?php if (!get_theme_mod('active_allegati_contenuto'))
-                                    get_template_part('template-parts/attachments-sidebar'); ?>
+                                    get_template_part('template-parts','attachments-sidebar'); ?>
                             
-                            <?php get_template_part('template-parts/sidebar-page'); ?>
+                            <?php get_template_part('template-parts','sidebar-page'); ?>
                         </aside>
                     </div>
                     <div class="col-lg-9 col-md-8 linetop pt8">
@@ -43,7 +43,7 @@ if (have_posts()) : while (have_posts()) : the_post(); ?>
                             </div>
                             
                             <?php if (get_theme_mod('active_allegati_contenuto'))
-                                    get_template_part('template-parts/attachments'); ?>
+                                    get_template_part('template-parts','attachments'); ?>
                             
                         </div>
                         
@@ -71,5 +71,5 @@ if (have_posts()) : while (have_posts()) : the_post(); ?>
         </section>
 
 <?php endwhile;
-      else : include('error.php');
+      else : get_template_part('template-parts','error');
       endif;

--- a/italiawp2/template-parts/attachments-sidebar.php
+++ b/italiawp2/template-parts/attachments-sidebar.php
@@ -10,9 +10,8 @@
 ?>
 
 <?php
-include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
-
-if (is_plugin_active('attachments/index.php')) { ?>
+  if ( in_array( 'attachments/wp-attachments.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) ) ) {
+  ?>
                 
 <?php $attachments = new Attachments('attachments'); ?>
 <?php if ($attachments->exist()) : ?>
@@ -36,4 +35,5 @@ if (is_plugin_active('attachments/index.php')) { ?>
 
 <?php endif; ?>
 
-<?php }
+<?php
+  }

--- a/italiawp2/template-parts/attachments.php
+++ b/italiawp2/template-parts/attachments.php
@@ -10,9 +10,8 @@
 ?>
 
 <?php
-include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 
-if (is_plugin_active('attachments/index.php')) { ?>
+if ( in_array( 'attachments/wp-attachments.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) ) ) { ?>
                 
 <?php $attachments = new Attachments('attachments'); ?>
 <?php if ($attachments->exist()) : ?>

--- a/italiawp2/template-parts/circolare-loop.php
+++ b/italiawp2/template-parts/circolare-loop.php
@@ -124,5 +124,5 @@ if (have_posts()) : while (have_posts()) : the_post();
         <?php get_template_part('template-parts/navigation'); ?>
 
 <?php endwhile;
-      else : include('error.php');
+      else : get_template_part('template-parts','error');
       endif; ?>

--- a/italiawp2/template-parts/custom-post-type-loop.php
+++ b/italiawp2/template-parts/custom-post-type-loop.php
@@ -84,5 +84,5 @@ if (have_posts()) : while (have_posts()) : the_post();
         <?php get_template_part('template-parts/navigation'); ?>
 
 <?php endwhile;
-      else : include('error.php');
+      else : get_template_part('template-parts','error');
       endif; ?>

--- a/italiawp2/template-parts/main-loop.php
+++ b/italiawp2/template-parts/main-loop.php
@@ -127,11 +127,11 @@ $i = 0; if (have_posts()) :
             </div>
 
 <?php endwhile;
-      else : include('error.php');
+      else : get_template_part('template-parts','error');
       endif; ?>
 
         </div>
     </div>
 </section>
 
-<?php include_once('pagination.php');
+<?php get_template_part('template-parts','pagination');

--- a/italiawp2/template-parts/page-loop-nosidebar.php
+++ b/italiawp2/template-parts/page-loop-nosidebar.php
@@ -73,5 +73,5 @@ if (have_posts()) : while (have_posts()) : the_post();
         </section>
 
 <?php endwhile;
-      else : include('error.php');
+      else : get_template_part('template-parts','error');
       endif; ?>

--- a/italiawp2/template-parts/page-loop.php
+++ b/italiawp2/template-parts/page-loop.php
@@ -60,12 +60,12 @@ if (have_posts()) : while (have_posts()) : the_post();
                 <div class="row">
                     <div class="col-lg-3 col-md-4 lineright">
                         <aside id="menu-sinistro">
-                            <?php include_once('children-list.php'); ?>
+                            <?php get_template_part('template-parts','children-list'); ?>
             
                             <?php if (!get_theme_mod('active_allegati_contenuto'))
-                                    get_template_part('template-parts/attachments-sidebar'); ?>
+                                    get_template_part('template-parts','attachments-sidebar'); ?>
                             
-                            <?php get_template_part('template-parts/sidebar-page'); ?>
+                            <?php get_template_part('template-parts','sidebar-page'); ?>
                         </aside>
                     </div>
                     <div class="col-lg-9 col-md-8 linetop pt8">
@@ -105,5 +105,5 @@ if (have_posts()) : while (have_posts()) : the_post();
         </section>
 
 <?php endwhile;
-      else : include('error.php');
+      else : get_template_part('template-parts','error');
       endif; ?>

--- a/italiawp2/template-parts/search-loop.php
+++ b/italiawp2/template-parts/search-loop.php
@@ -42,8 +42,10 @@
 
     if (have_posts()) :
     while (have_posts()) : the_post();
-    
-    $category = get_the_category(); $first_category = $category[0];
+
+    $first_category = ( ($category = get_the_category()) && !empty($category) ) ? $category[0] : null;
+
+
     $datapost = get_the_date('j F Y', '', ''); ?>
                         
                         <div class="col-lg-4 col-md-12">
@@ -76,7 +78,7 @@
                         </div>
 
 <?php endwhile;
-      else : include('error.php');
+      else : get_template_part('template-parts','error');
       endif; ?>
 
                     </div>
@@ -86,4 +88,4 @@
     </div>
 </section>
 
-<?php include_once('pagination.php');
+<?php get_template_part('template-parts','pagination');

--- a/italiawp2/template-parts/section-map.php
+++ b/italiawp2/template-parts/section-map.php
@@ -19,5 +19,5 @@
 
 <section class="map-full-content">
     <div class="map-wrap"></div>
-    <iframe src="<?php echo get_option('dettagli-map'); ?>" frameborder="0" allowfullscreen></iframe>
+    <iframe src="<?php echo sanitize_text_field(get_option('dettagli-map')); ?>" frameborder="0" allowfullscreen></iframe>
 </section>

--- a/italiawp2/template-parts/single-loop.php
+++ b/italiawp2/template-parts/single-loop.php
@@ -139,5 +139,5 @@ if (have_posts()) : while (have_posts()) : the_post();
         <?php get_template_part('template-parts/navigation'); ?>
 
 <?php endwhile;
-      else : include('error.php');
+      else : get_template_part('template-parts','error');
       endif; ?>


### PR DESCRIPTION
- Ho sostituito gli include con get_template_part() che è più utile se lavoriamo con i child
- Aggiunto il colore bianco e nero alla palette di gutenberg (perchè se no non potevamo fare i tasti blu con il testo bianco per esempio)
- Dato che caricare plugin.php consuma risorse ho sostituito con function_exist o class_exist (tanto se il plugin è caricato quella funzione/classe c'è)
- Ho corretto un errore che si vedeva con il debug attivato nella pagina con il loop degli articoli, perchè get_categories quando non ci sono categorie torna un array vuoto ma veniva stampato l'elemento array[0] (index non esistente)
- Aggiunto un paio di sanitizzazioni che non avevo visto