### PR TITLE
Mostrata hero-foto solo se l'header image è impostata

### DIFF
--- a/italiawp2/template-parts/section-hero.php
+++ b/italiawp2/template-parts/section-hero.php
@@ -4,11 +4,13 @@
  * Solo immagine
  *
  */
+$headerImage = get_header_image();
 ?>
 
+<?php if ($headerImage): ?>
 <style>
     #hero .hero-foto {
-        background-image: url('<?php echo esc_url( get_header_image() ); ?>') !important;
+        background-image: url('<?php echo esc_url( $headerImage ); ?>') !important;
     }
 </style>
 
@@ -17,3 +19,4 @@
         <div class="hero-foto"></div>
     </div>
 </section>
+<?php endif; ?>


### PR DESCRIPTION
Salve ragazzi!

Volevo prima di tutto ringraziarvi per il tema poi volevo suggerire la possibilità di mostrare la sezione dell'.hero-foto solo se l'header image è impostata.

Ho fatto questa PR in quanto potrebbe risultare antiestetico mostrare un box bianco di 500px se l'immagine non è presente.